### PR TITLE
Update Frameworks to not use $option->name

### DIFF
--- a/src/FormModel/Frameworks/Bootstrap.php
+++ b/src/FormModel/Frameworks/Bootstrap.php
@@ -84,7 +84,8 @@ class Bootstrap extends FrameworkInputs implements FrameworkInterface
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
+                            $this->accessor = !empty($option->form_name) ? $option->form_model : 'name' ;
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$this->accesor}));
                         }
                         $relation = $this->model->{trim($input, '_id')};
                         if($relation instanceof Collection && $relation->count() === 1)

--- a/src/FormModel/Frameworks/Bootstrap.php
+++ b/src/FormModel/Frameworks/Bootstrap.php
@@ -84,7 +84,7 @@ class Bootstrap extends FrameworkInputs implements FrameworkInterface
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->name));
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
                         }
                         $relation = $this->model->{trim($input, '_id')};
                         if($relation instanceof Collection && $relation->count() === 1)

--- a/src/FormModel/Frameworks/BootstrapVue.php
+++ b/src/FormModel/Frameworks/BootstrapVue.php
@@ -58,7 +58,7 @@ class BootstrapVue extends Bootstrap
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->name));
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
                         }
                         $default = empty($this->model->{trim($input, '_id')}->id) ? '' : $this->model->{trim($input, '_id')}->id;
 

--- a/src/FormModel/Frameworks/BootstrapVue.php
+++ b/src/FormModel/Frameworks/BootstrapVue.php
@@ -58,7 +58,8 @@ class BootstrapVue extends Bootstrap
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
+                            $this->accessor = !empty($option->form_name) ? $option->form_model : 'name' ;
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$this->accesor}));
                         }
                         $default = empty($this->model->{trim($input, '_id')}->id) ? '' : $this->model->{trim($input, '_id')}->id;
 

--- a/src/FormModel/Frameworks/Materialize.php
+++ b/src/FormModel/Frameworks/Materialize.php
@@ -87,12 +87,8 @@ class Materialize extends FrameworkInputs implements FrameworkInterface
                 if ($options instanceof Collection) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            try {
-                                $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
-                            } catch (\Exception $e) {
-                                dd($options);
-                            }
-                        }
+                            $this->accessor = !empty($option->form_name) ? $option->form_model : 'name' ;
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$this->accesor}));                        }
 
                         return $this->select([
                             'default' => 'Please select a '.trim($input, '_id').' to assign this to',

--- a/src/FormModel/Frameworks/Materialize.php
+++ b/src/FormModel/Frameworks/Materialize.php
@@ -88,7 +88,7 @@ class Materialize extends FrameworkInputs implements FrameworkInterface
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
                             try {
-                                $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->name));
+                                $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
                             } catch (\Exception $e) {
                                 dd($options);
                             }

--- a/src/FormModel/Frameworks/MaterializeVue.php
+++ b/src/FormModel/Frameworks/MaterializeVue.php
@@ -58,7 +58,7 @@ class MaterializeVue extends Materialize
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->name));
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
                         }
                         $default = empty($this->model->{trim($input, '_id')}->id) ? '' : $this->model->{trim($input, '_id')}->id;
 

--- a/src/FormModel/Frameworks/MaterializeVue.php
+++ b/src/FormModel/Frameworks/MaterializeVue.php
@@ -58,7 +58,8 @@ class MaterializeVue extends Materialize
                 if (!empty($options)) {
                     if (!$options->isEmpty()) {
                         foreach ($options as $option) {
-                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$option->form_name}));
+                            $this->accessor = !empty($option->form_name) ? $option->form_model : 'name' ;
+                            $ops[$option->id] = ucwords(preg_replace('/[-_]+/', ' ', $option->{$this->accesor}));
                         }
                         $default = empty($this->model->{trim($input, '_id')}->id) ? '' : $this->model->{trim($input, '_id')}->id;
 

--- a/src/FormModel/Interfaces/FrameworkInputs.php
+++ b/src/FormModel/Interfaces/FrameworkInputs.php
@@ -21,6 +21,10 @@ abstract class FrameworkInputs
      */
     protected $location;
 
+    /**
+     * @var
+     */
+    protected $accessor;
     public function plainTextarea($options, $text = '')
     {
         return '<textarea'.$this->attributes($options).'>'.

--- a/src/FormModel/Interfaces/FrameworkInputs.php
+++ b/src/FormModel/Interfaces/FrameworkInputs.php
@@ -3,9 +3,11 @@
 namespace Kregel\FormModel\Interfaces;
 
 use Illuminate\Database\Eloquent\Model;
+use Kregel\FormModel\Traits\Formable;
 
 abstract class FrameworkInputs
 {
+    use Formable;
     /**
      * @var
      */

--- a/src/FormModel/Traits/Formable.php
+++ b/src/FormModel/Traits/Formable.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kregel\FormModel\Traits;
+
+class FormModel
+{
+    protected $form_name;
+
+    /**
+     * @return mixed
+     */
+    public function getFormName()
+    {
+        return $this->form_name;
+    }
+
+    /**
+     * @param mixed $form_name
+     */
+    public function setFormName($form_name)
+    {
+        $this->form_name = $form_name;
+    }
+
+}

--- a/src/FormModel/Traits/Formable.php
+++ b/src/FormModel/Traits/Formable.php
@@ -2,7 +2,7 @@
 
 namespace Kregel\FormModel\Traits;
 
-class FormModel
+trait Formable
 {
     protected $form_name;
 


### PR DESCRIPTION
I realized after a while that FormModel was being used by Warden to generate the pages.

I saw that it was only pulling the `name` attribute from the given model, I don't like using name, I use title. So this pull request will add a form
